### PR TITLE
set sleep to 12, in line with suggested rate limits

### DIFF
--- a/R/books.R
+++ b/R/books.R
@@ -53,7 +53,7 @@ ny_book_list <- function(list, bestsellers_date = NULL, published_date = NULL, p
     page_content <- content(response)
     content <- append(content, list(page_content$results))
     results <- results + page_content$num_results
-    if(pages > 0) Sys.sleep(6)
+    if(pages > 0) Sys.sleep(12)
     p <- p + 1
   }
 
@@ -94,7 +94,7 @@ ny_book_date_list <- function(list, published_date = NULL, pages = 1){
     page_content <- content(response)
     content <- append(content, list(page_content$results))
     results <- results + page_content$num_results
-    if(p > 1) Sys.sleep(6)
+    if(p > 1) Sys.sleep(12)
     p <- p + 1
   }
 
@@ -211,7 +211,7 @@ ny_book_history <- function(age_group = NULL, author = NULL, contributor = NULL,
     page_content <- content(response)
     content <- append(content, list(page_content$results))
     results <- results + page_content$num_results
-    if(p > 1) Sys.sleep(6)
+    if(p > 1) Sys.sleep(12)
     p <- p + 1
   }
 

--- a/R/geo.R
+++ b/R/geo.R
@@ -55,7 +55,7 @@ ny_geo <- function(name = NULL, longitude = NULL, latitude = NULL, ne = NULL, sw
     page_content <- content(response)
     content <- append(content, list(page_content$results))
     results <- results + page_content$num_results
-    if(p > 1) Sys.sleep(6)
+    if(p > 1) Sys.sleep(12)
     p <- p + 1
   }
 

--- a/R/movies.R
+++ b/R/movies.R
@@ -121,7 +121,7 @@ ny_movie_search <- function(q, picks = FALSE, pages = 1, opening_since = NULL, o
     offset <- offset + 20
     if(p != 1) {
       pb$tick()
-      Sys.sleep(6)
+      Sys.sleep(12)
     }
     
     if(!isTRUE(page_content$has_more))

--- a/R/search.R
+++ b/R/search.R
@@ -66,7 +66,7 @@ ny_search <- function(q, since = NULL, until = NULL, pages = 1, sort = c("newest
       cat(crayon::blue(cli::symbol$info), hits, "results available\n")
     } else {
       pb$tick()
-      Sys.sleep(6)
+      Sys.sleep(12)
     }
     
     if(offset >= hits)

--- a/R/semantic.R
+++ b/R/semantic.R
@@ -76,7 +76,7 @@ ny_semantic_search <- function(q, pages = 1, fields = "all") {
     offset <- offset + 20
     if(p != 1) {
       pb$tick()
-      Sys.sleep(6)
+      Sys.sleep(12)
     } else {
       cat(crayon::blue(cli::symbol$info), page_content$num_results, "results available\n")
     }

--- a/R/wire.R
+++ b/R/wire.R
@@ -90,7 +90,7 @@ ny_wire_source <- function(section, pages = 1, source = c("all", "nyt", "iht")) 
     if(p == 0)
       cat(crayon::blue(cli::symbol$info), page_content$num_results, "results available\n")
     content <- append(content, list(page_content$results))
-    if(pages > 0) Sys.sleep(6)
+    if(pages > 0) Sys.sleep(12)
     p <- p + 1
     if(length(content) * 20  >= page_content$num_results)
       break
@@ -134,7 +134,7 @@ ny_wire_period <- function(section, period = 12, pages = 1, source = c("all", "n
     if(p == 0)
       cat(crayon::blue(cli::symbol$info), page_content$num_results, "results available\n")
     content <- append(content, list(page_content$results))
-    if(pages > 0) Sys.sleep(6)
+    if(pages > 0) Sys.sleep(12)
     p <- p + 1
     if(length(content) * 20  >= page_content$num_results)
       break


### PR DESCRIPTION
At present, any call retrieving more than 50 items leads to the following error message:
`Too Many Requests (RFC 6585) (HTTP 429)`. 

The [official FAQ](https://developer.nytimes.com/faq) suggests to wait for 12 seconds between calls
> there are two rate limits per API: 500 requests per day and 5 requests per minute. You should sleep 12 seconds between calls to avoid hitting the per minute rate limit.

In the past it was probably 6 seconds.