### PR TITLE
Fix search function: zero-based pagination, better progress

### DIFF
--- a/R/search.R
+++ b/R/search.R
@@ -50,7 +50,7 @@ ny_search <- function(q, since = NULL, until = NULL, pages = 1, sort = c("newest
   )
   
   content <- list()
-  for(p in 1:pages){
+  for(p in 0:pages){
     opts$page <- p
     parsed_url$query <- opts
     url <- build_url(parsed_url)
@@ -62,7 +62,7 @@ ny_search <- function(q, since = NULL, until = NULL, pages = 1, sort = c("newest
     # check if results left
     hits <- page_content$response$meta$hits
     offset <- page_content$response$meta$offset
-    if(p == 1){
+    if(p == 0){
       cat(crayon::blue(cli::symbol$info), hits, "results available\n")
     } else {
       pb$tick()


### PR DESCRIPTION
There was a bug in the search function: the API starts at page 0, but the code started from page 1, causing the first page or results to be missing. 

I've also improved the progress bar to use the actual number of pages if lower than the maximum number of pages (especially useful if pages=Inf)

I've also made two changes that you may or may not agree with:
- I've increased the sleep to 13 as it was sometimes giving a 'too many requests' error 
- I've changed the return type to a simple list of documents rather than the nested structure it previously returned. I don't think the result metadata will be very useful for anyone and many people have difficulty dealing with nested structures in R, so this seemed the better choice.

Please let me know if you want me to revert any of these additional changes!